### PR TITLE
LinuxArtistMode: Move BTN_TOUCH behavior to new binding handler

### DIFF
--- a/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
+++ b/OpenTabletDriver.Desktop/Binding/LinuxArtistMode/LinuxArtistModeButtonBinding.cs
@@ -14,6 +14,7 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
         private readonly EvdevVirtualTablet virtualTablet = (EvdevVirtualTablet)DesktopInterop.VirtualTablet;
 
         public static string[] ValidButtons { get; } = {
+            "Pen Tip",
             "Pen Button 1",
             "Pen Button 2",
             "Pen Button 3"
@@ -36,6 +37,7 @@ namespace OpenTabletDriver.Desktop.Binding.LinuxArtistMode
         {
             var eventCode = Button switch
             {
+                "Pen Tip"      => EventCode.BTN_TOUCH,
                 "Pen Button 1" => EventCode.BTN_STYLUS,
                 "Pen Button 2" => EventCode.BTN_STYLUS2,
                 "Pen Button 3" => EventCode.BTN_STYLUS3,

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -40,6 +40,8 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
             var pressure = new input_absinfo
             {
+                // FIXME: setting 'flat' attribute is a hack to workaround GNOME interpreting any pressure as pen button
+                flat = (int)(MaxPressure * 0.01),
                 maximum = MaxPressure
             };
             input_absinfo* pressurePtr = &pressure;

--- a/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
+++ b/OpenTabletDriver.Desktop/Interop/Input/Absolute/EvdevVirtualTablet.cs
@@ -96,7 +96,6 @@ namespace OpenTabletDriver.Desktop.Interop.Input.Absolute
 
         public void SetPressure(float percentage)
         {
-            Device.Write(EventType.EV_KEY, EventCode.BTN_TOUCH, percentage > 0 ? 1 : 0);
             Device.Write(EventType.EV_ABS, EventCode.ABS_PRESSURE, (int)(MaxPressure * percentage));
         }
 


### PR DESCRIPTION
Without this change, `BTN_TOUCH` would get emitted as soon as any pressure was detected because of side effects from #1736.