### PR TITLE
Fix Linux build

### DIFF
--- a/eng/linux/package.sh
+++ b/eng/linux/package.sh
@@ -12,7 +12,6 @@ fi
 PACKAGE_GEN=""
 PROJECTS=(
   "OpenTabletDriver.Daemon"
-  "OpenTabletDriver.Console"
   "OpenTabletDriver.UX.Gtk"
 )
 

--- a/eng/linux/package.sh
+++ b/eng/linux/package.sh
@@ -12,7 +12,7 @@ fi
 PACKAGE_GEN=""
 PROJECTS=(
   "OpenTabletDriver.Daemon"
-  "OpenTabletDriver.UX.Gtk"
+  "OpenTabletDriver.UI"
 )
 
 MOVE_RULES_TO_ETC="false"


### PR DESCRIPTION
doesn't `./build.sh` without this